### PR TITLE
Update ESLint version in response to security alert.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2019-07-19
+
+### Security
+
+* Update ESLint dependencies (dev and peer) to at least 4.18.2 in response to [ESLint #10002](https://github.com/eslint/eslint/issues/10002).
+
+## [1.0.0] - 2018-08-17
+
+## [0.0.1] - 2016-10-28
+
+[Unreleased]: https://github.com/bis-public/eslint-config-bis/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/bis-public/eslint-config-bis/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/bis-public/eslint-config-bis/compare/v0.0.1...v1.0.0
+[0.0.1]: https://github.com/bis-public/eslint-config-bis/releases/tag/v0.0.1

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "eslint-config-bis",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ESLint configuration to help comply with BIS JavaScript standards.",
   "main": "index.js",
   "author": "Dylan Kerr",
   "license": "ISC",
   "devDependencies": {
-    "eslint": "^3.10.0"
+    "eslint": "^4.18.2"
   },
   "peerDependencies": {
-    "eslint": ">=3.10.0"
+    "eslint": ">=4.18.2"
   }
 }


### PR DESCRIPTION
Breaking change, at least because our config extends the recommended config which has breaking changes between v3 and v4.